### PR TITLE
Speedup by relying on filesystem ctime/mtime/filesize

### DIFF
--- a/lib/commit.dart
+++ b/lib/commit.dart
@@ -128,9 +128,11 @@ extension Commit on GitRepository {
     // Write all the tree objects
     var hashMap = <String, GitHash>{};
 
+    // sort dir paths by number of slashes
     var allDirs = allTreeDirs.toList();
     allDirs.sort(dirSortFunc);
 
+    // `reversed`-> start with the deepest folders (why?)
     for (var dir in allDirs.reversed) {
       var tree = treeObjects[dir]!;
       var entries = tree.entries.unlock;
@@ -140,9 +142,10 @@ extension Commit on GitRepository {
         var leaf = entries[i];
 
         if (leaf.hash.isNotEmpty) {
-          //
-          // Making sure the leaf is a blob
-          //
+          // Making sure the leaf is a blob.
+          // This is slow because it reads every leaf,
+          // but that is alright because asserts get
+          // removed for release builds.
           assert(() {
             var leafObj = objStorage.read(leaf.hash);
             return leafObj?.formatStr() == 'blob';


### PR DESCRIPTION
On my test repo with a few text files and some images, but not too large (194 MB in total) this speeds "add" and "commit" up as follows:

* When the command is "add", this takes 2 seconds without my ctime/mtime patch and ~0.2 without.
* When the command is "commit", this takes 2 seconds but only due to asserts that get removed for release builds..

The use-case I have in mind is that GitJournal takes 30 seconds to startup on my phone, using this same folder of notes files. This PR makes that usable again.

The trick is to assume files are unchanged when their mTime, cTime, and filesize, have not been modified since the last time we have read and hashed the full file. This saves a lot of time and is true in roughly all reasonable use-cases. I believe that the original git implementation also does this (though I did not double-check their source code).