### PR TITLE
Fix tree object modes and ordering

### DIFF
--- a/lib/plumbing/index.dart
+++ b/lib/plumbing/index.dart
@@ -281,7 +281,7 @@ class GitIndexEntry {
       mTime: stat.mTime,
       dev: stat.dev,
       ino: stat.ino,
-      mode: GitFileMode(stat.mode),
+      mode: GitFileMode.fromFileStatMode(stat.mode),
       uid: stat.uid,
       gid: stat.gid,
       fileSize: stat.fileSize,

--- a/lib/plumbing/objects/tree.dart
+++ b/lib/plumbing/objects/tree.dart
@@ -38,7 +38,8 @@ class GitTree extends GitObject {
   GitTree._(this.hash, this.entries);
 
   static GitTree create([Iterable<GitTreeEntry>? entries]) {
-    var t = GitTree._(GitHash.zero(), IList(entries));
+    var sortedEntries = [...?entries]..sort(compareTreeEntries);
+    var t = GitTree._(GitHash.zero(), IList(sortedEntries));
     var hash = GitHash.computeForObject(t);
     return GitTree._(hash, t.entries);
   }
@@ -97,4 +98,27 @@ class GitTree extends GitObject {
       print('${e.mode} ${e.name} ${e.hash}');
     }
   }
+}
+
+int compareTreeEntries(GitTreeEntry a, GitTreeEntry b) {
+  var aName = utf8.encode(a.name);
+  var bName = utf8.encode(b.name);
+  var commonLength = aName.length < bName.length ? aName.length : bName.length;
+
+  for (var i = 0; i < commonLength; i++) {
+    var diff = aName[i] - bName[i];
+    if (diff != 0) return diff;
+  }
+
+  var aTerminator = aName.length == commonLength
+      ? _treeSortTerminator(a)
+      : aName[commonLength];
+  var bTerminator = bName.length == commonLength
+      ? _treeSortTerminator(b)
+      : bName[commonLength];
+  return aTerminator - bTerminator;
+}
+
+int _treeSortTerminator(GitTreeEntry entry) {
+  return entry.mode == GitFileMode.Dir ? $slash : 0;
 }

--- a/lib/utils/file_mode.dart
+++ b/lib/utils/file_mode.dart
@@ -24,6 +24,11 @@ class GitFileMode extends Equatable {
   static final Symlink = GitFileMode(int.parse('120000', radix: 8));
   static final Submodule = GitFileMode(int.parse('160000', radix: 8));
 
+  static GitFileMode fromFileStatMode(int mode) {
+    const executableBits = 0x49; // 0111 in octal: owner/group/other execute.
+    return mode & executableBits == 0 ? Regular : Executable;
+  }
+
   @override
   List<Object> get props => [val];
 

--- a/test/index_test.dart
+++ b/test/index_test.dart
@@ -5,6 +5,7 @@ import 'package:test/test.dart';
 import 'package:dart_git/plumbing/git_hash.dart';
 import 'package:dart_git/plumbing/index.dart';
 import 'package:dart_git/utils/file_mode.dart';
+import 'package:dart_git/utils/git_file_stat.dart';
 
 void main() {
   test('Decode', () async {
@@ -105,6 +106,24 @@ void main() {
 
     expect(rIndex.versionNo, index.versionNo);
     expect(rIndex.entries, index.entries);
+  });
+
+  test('normalizes filesystem file modes for git index entries', () {
+    var hash = GitHash('e25b29c8946e0e192fae2edc1dabf7be71e8ecf3');
+    var stat = GitFileStat(
+      cTime: DateTime.utc(2026, 1, 1),
+      mTime: DateTime.utc(2026, 1, 1),
+      dev: 0,
+      ino: 0,
+      mode: int.parse('100600', radix: 8),
+      uid: 0,
+      gid: 0,
+      fileSize: 42,
+    );
+
+    var entry = GitIndexEntry.fromFS('note.md', stat, hash);
+
+    expect(entry.mode, GitFileMode.Regular);
   });
 
   test('Decode Merge Conflict', () {

--- a/test/plumbing/objects/tree_test.dart
+++ b/test/plumbing/objects/tree_test.dart
@@ -8,6 +8,7 @@ import 'package:dart_git/plumbing/git_hash.dart';
 import 'package:dart_git/plumbing/objects/object.dart';
 import 'package:dart_git/plumbing/objects/tree.dart';
 import 'package:dart_git/storage/object_storage_fs.dart';
+import 'package:dart_git/utils/file_mode.dart';
 
 void main() {
   test('Reads the tree file correctly', () async {
@@ -44,5 +45,16 @@ void main() {
     expect(
         GitObject.envelope(data: tree.serializeData(), format: tree.format()),
         equals(fileBytesDefalted));
+  });
+
+  test('Sorts tree entries using git tree ordering', () {
+    var hash = GitHash('e25b29c8946e0e192fae2edc1dabf7be71e8ecf3');
+    var tree = GitTree.create([
+      GitTreeEntry(mode: GitFileMode.Regular, name: 'a0.md', hash: hash),
+      GitTreeEntry(mode: GitFileMode.Dir, name: 'a', hash: hash),
+      GitTreeEntry(mode: GitFileMode.Regular, name: 'a.md', hash: hash),
+    ]);
+
+    expect(tree.entries.map((entry) => entry.name), ['a.md', 'a', 'a0.md']);
   });
 }


### PR DESCRIPTION
## Summary

Fix Git tree objects generated from the worktree so they pass remote fsck checks:

- normalize filesystem modes to Git tree modes before writing index entries
- sort `GitTree` entries using Git tree ordering before hashing/serializing
- add regression tests for both cases

## Motivation

GitJournal mobile sync can create commits locally with malformed tree objects. When those objects are pushed to GitHub, GitHub rejects the pack with errors such as:

```text
badFilemode: contains bad file modes
treeNotSorted: not properly sorted
fatal: fsck error in packed object
```

This showed up in GitJournal as `malformed unpack status: 001dunpack index-pack failed`. I added more detail to the related GitJournal issue here:

https://github.com/GitJournal/GitJournal/issues/963#issuecomment-4993660823

## Details

`GitIndexEntry.fromFS` previously used `FileStat.mode` directly. On platforms such as Android/Linux this can include filesystem file type and permission bits that are not valid Git tree modes. This PR maps filesystem modes to `100644` or `100755` before they are written to the index.

`GitTree.create` now sorts entries before computing the tree hash. Directories are compared as `name/`, matching Git tree ordering.

## Tests

```text
dart test test/index_test.dart test/plumbing/objects/tree_test.dart --reporter compact
dart analyze
```
